### PR TITLE
Further reduce dependencies for cross-platform

### DIFF
--- a/src/IfSharp.Kernel/IfSharp.Kernel.fsproj
+++ b/src/IfSharp.Kernel/IfSharp.Kernel.fsproj
@@ -109,8 +109,6 @@
     <Reference Include="System.Configuration" />
     <Reference Include="System.Numerics" />
     <Reference Include="System.Web" />
-    <Reference Include="System.Windows.Forms" />
-    <Reference Include="System.Windows.Forms.DataVisualization" />
     <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />
   </ItemGroup>


### PR DESCRIPTION
We don't actually need these references in the core now. The code that
needed them has been moved out into .fsx e.g FSharp.Charting.fsx